### PR TITLE
Feat/journey and running

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,10 @@ import Main from "./Pages/Main";
 import RunSummaryScreen from "./Pages/RunSummaryscreen";
 import LiveRunningScreen from "./Pages/LiveRunningScreen";
 import RunningComplete from "./Pages/RunningComplete";
+import JourneyRouteListScreen from "./Pages/JourneyRouteListScreen";
+import JourneyRouteDetailScreen from "./Pages/JourneyRouteDetailScreen";
+import JourneyLoadingScreen from "./Pages/JourneyLoadingScreen";
+import JourneyGuideScreen from "./Pages/JourneyGuideScreen";
 import Feed from "./Pages/FeedScreen";
 import Feed2 from "./Pages/FeedScreen2";
 import FeedDetail from "./Pages/FeedDetail";
@@ -42,6 +46,11 @@ export default function App() {
         <Stack.Screen name="LoginSuccess" component={LoginSuccessScreen} />
         <Stack.Screen name="Main" component={Main} />
         <Stack.Screen name="LiveRunningScreen" component={LiveRunningScreen} />
+        {/* 여정 러닝: 로딩/가이드/리스트/디테일 */}
+        <Stack.Screen name="JourneyLoading" component={JourneyLoadingScreen} />
+        <Stack.Screen name="JourneyGuide" component={JourneyGuideScreen} />
+        <Stack.Screen name="JourneyRouteList" component={JourneyRouteListScreen} />
+        <Stack.Screen name="JourneyRouteDetail" component={JourneyRouteDetailScreen} />
         <Stack.Screen name="RunningComplete" component={RunningComplete} />
         <Stack.Screen
           name="RunSummary"

--- a/Pages/GuestbookScreen.tsx
+++ b/Pages/GuestbookScreen.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { View, Text, SafeAreaView, StyleSheet } from "react-native";
+
+export default function GuestbookScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={{ padding: 16 }}>
+        <Text style={styles.title}>방명록</Text>
+        <Text style={{ color: "#6b7280", marginTop: 6 }}>목 데이터 기반 예시 화면</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+  title: { fontSize: 20, fontWeight: "800" },
+});
+

--- a/Pages/JourneyGuideScreen.tsx
+++ b/Pages/JourneyGuideScreen.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, StatusBar, ScrollView } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export default function JourneyGuideScreen({ navigation }: { navigation: any }) {
+  const onStart = async () => {
+    await AsyncStorage.setItem('journeyGuideSeen', '1');
+    navigation.replace('JourneyRouteList');
+  };
+  const onSkip = async () => {
+    await AsyncStorage.setItem('journeyGuideSeen', '1');
+    navigation.reset({ index: 0, routes: [{ name: 'Main' }] });
+  };
+  return (
+    <View style={s.container}>
+      <StatusBar barStyle="dark-content" backgroundColor="#FFFFFF" />
+      <ScrollView contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>
+        <Text style={s.title}>여정 러닝 안내</Text>
+        <Text style={s.desc}>
+          가상러닝(여정 러닝)은 실제 위치 기반 러닝에 목표 거리를 더해
+          특정 코스를 가상으로 완주하는 기능입니다.{"\n\n"}
+          - 여정을 선택하고{` `}목표 거리로 자동 완료{` `}됩니다.{"\n"}
+          - 여정의 랜드마크를 따라 진행 상황을 확인할 수 있어요.{"\n"}
+          - 기존 러닝 로직과 동일하게 페이스, 거리, 칼로리를 기록합니다.
+        </Text>
+
+        <View style={s.card}>
+          <Text style={s.cardTitle}>어떻게 사용하나요?</Text>
+          <Text style={s.cardItem}>1) 여정 선택 → 상세에서 '여정 계속하기'</Text>
+          <Text style={s.cardItem}>2) 러닝 시작 → 목표 거리 도달 시 자동 완료</Text>
+          <Text style={s.cardItem}>3) 요약 화면에서 공유/기록 확인</Text>
+        </View>
+
+        <View style={s.btnWrap}>
+          <TouchableOpacity style={s.primary} onPress={onStart}>
+            <Text style={s.primaryText}>시작하기</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={s.secondary} onPress={onSkip}>
+            <Text style={s.secondaryText}>다시 보지 않기</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { padding: 20, paddingTop: 40 },
+  title: { fontSize: 24, fontWeight: '800', color: '#111827', marginBottom: 16 },
+  desc: { color: '#4B5563', lineHeight: 22, marginBottom: 20 },
+  card: { backgroundColor: '#F9FAFB', borderRadius: 12, padding: 16, marginTop: 8, marginBottom: 24, borderWidth: StyleSheet.hairlineWidth, borderColor: '#E5E7EB' },
+  cardTitle: { fontSize: 16, fontWeight: '800', marginBottom: 8, color: '#1F2937' },
+  cardItem: { color: '#374151', marginTop: 4 },
+  btnWrap: { gap: 12 },
+  primary: { backgroundColor: '#6366F1', paddingVertical: 14, borderRadius: 12, alignItems: 'center' },
+  primaryText: { color: '#fff', fontWeight: '800' },
+  secondary: { borderWidth: 1, borderColor: '#D1D5DB', paddingVertical: 14, borderRadius: 12, alignItems: 'center' },
+  secondaryText: { color: '#6B7280', fontWeight: '700' },
+});
+

--- a/Pages/JourneyLoadingScreen.tsx
+++ b/Pages/JourneyLoadingScreen.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Animated, Dimensions, StatusBar } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LinearGradient } from 'expo-linear-gradient';
+
+const { width, height } = Dimensions.get('window');
+
+export default function JourneyLoadingScreen({ navigation }: { navigation: any }) {
+  const [progress] = useState(new Animated.Value(0));
+  const [loadingText, setLoadingText] = useState('앱을 로딩하고 있습니다..');
+
+  useEffect(() => {
+    const loadingTexts = ['앱을 로딩하고 있습니다.', '앱을 로딩하고 있습니다..', '앱을 로딩하고 있습니다...'];
+
+    let textIndex = 0;
+    const textInterval = setInterval(() => {
+      textIndex = (textIndex + 1) % loadingTexts.length;
+      setLoadingText(loadingTexts[textIndex]);
+    }, 500);
+
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: 3000,
+      useNativeDriver: false,
+    }).start(async () => {
+      clearInterval(textInterval);
+      try {
+        const seen = await AsyncStorage.getItem('journeyGuideSeen');
+        if (seen === '1') navigation.replace('JourneyRouteList');
+        else navigation.replace('JourneyGuide');
+      } catch {
+        navigation.replace('JourneyGuide');
+      }
+    });
+
+    return () => clearInterval(textInterval);
+  }, [navigation, progress]);
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" backgroundColor="#6366F1" />
+      <LinearGradient colors={['#8B5CF6', '#6366F1']} style={styles.gradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}>
+        <View style={styles.content}>
+          <Text style={styles.logo}>로그</Text>
+
+          <View style={styles.titleContainer}>
+            <Text style={styles.title}>주제목</Text>
+            <Text style={styles.subtitle}>
+              달리며 떠나는 특별한 여행{"\n"}
+              세계 곳곳의 아름다운 여정을 경험하세요
+            </Text>
+          </View>
+
+          <View style={styles.loadingContainer}>
+            <View style={styles.progressBarContainer}>
+              <Animated.View
+                style={[
+                  styles.progressBar,
+                  { width: progress.interpolate({ inputRange: [0, 1], outputRange: ['0%', '100%'] }) },
+                ]}
+              />
+            </View>
+            <Text style={styles.loadingText}>{loadingText}</Text>
+          </View>
+        </View>
+      </LinearGradient>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  gradient: { flex: 1 },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 40,
+    paddingTop: height * 0.15,
+    paddingBottom: height * 0.1,
+  },
+  logo: { fontSize: 18, color: '#FFFFFF', fontWeight: '600', letterSpacing: 1 },
+  titleContainer: { alignItems: 'center', flex: 1, justifyContent: 'center' },
+  title: { fontSize: 32, fontWeight: 'bold', color: '#FFFFFF', marginBottom: 20, letterSpacing: -0.5 },
+  subtitle: { fontSize: 16, color: '#E0E7FF', textAlign: 'center', lineHeight: 24, opacity: 0.9 },
+  loadingContainer: { alignItems: 'center', width: '100%' },
+  progressBarContainer: {
+    width: width * 0.6,
+    height: 4,
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    borderRadius: 2,
+    marginBottom: 16,
+    overflow: 'hidden',
+  },
+  progressBar: { height: '100%', backgroundColor: '#FFFFFF', borderRadius: 2 },
+  loadingText: { fontSize: 14, color: '#E0E7FF', opacity: 0.8 },
+});

--- a/Pages/JourneyRouteDetailScreen.tsx
+++ b/Pages/JourneyRouteDetailScreen.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, StatusBar, Modal } from 'react-native';
+import useRouteDetail from '../hooks/journey/useJourneyRouteDetail';
+import type { RouteId } from '../utils/api/journeyRoutes';
+
+type RouteParams = { route: { params?: { id?: RouteId } } ; navigation?: any };
+
+export default function RouteDetailScreen({ route, navigation }: RouteParams) {
+  const id = route?.params?.id;
+  const { data, loading } = useRouteDetail(id);
+  const [showLandmarks, setShowLandmarks] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" backgroundColor="#1F2937" />
+
+      <View style={styles.headerContainer}>
+        <TouchableOpacity style={styles.backButton} onPress={() => navigation?.goBack?.()}>
+          <Text style={styles.backIcon}>←</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.menuButton}>
+          <Text style={styles.menuIcon}>⋯</Text>
+        </TouchableOpacity>
+
+        <View style={styles.headerContent}>
+          <Text style={styles.headerTitle}>{data?.title ?? '여정 상세'}</Text>
+          <View style={styles.headerBadge}>
+            <Text style={styles.headerBadgeText}>역사 탐방</Text>
+          </View>
+        </View>
+
+        <View style={styles.headerImagePlaceholder}>
+          <Text style={styles.headerImageIcon}>🏯</Text>
+        </View>
+      </View>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        {loading && (
+          <Text style={{ padding: 16, color: '#6B7280' }}>로딩 중...</Text>
+        )}
+        <View style={styles.infoCard}>
+          <Text style={styles.sectionTitle}>여정 소개</Text>
+          <Text style={styles.description}>{data?.description ?? '설명이 없습니다.'}</Text>
+
+          <Text style={styles.sectionTitle}>주요 랜드마크</Text>
+
+          <View style={styles.landmarksPreview}>
+            {(data?.landmarks || []).slice(0, 3).map((lm, idx) => (
+              <View key={lm.id} style={styles.landmarkItem}>
+                <View style={styles.landmarkNumber}>
+                  <Text style={styles.landmarkNumberText}>{idx + 1}</Text>
+                </View>
+                <View style={styles.landmarkInfo}>
+                  <Text style={styles.landmarkName}>{lm.name}</Text>
+                  <Text style={styles.landmarkDistance}>{lm.distance}</Text>
+                </View>
+                {lm.completed && (
+                  <View style={styles.completedBadge}>
+                    <Text style={styles.completedIcon}>✓</Text>
+                  </View>
+                )}
+              </View>
+            ))}
+
+            {(data?.landmarks?.length || 0) > 3 && (
+              <TouchableOpacity style={styles.showMoreButton} onPress={() => setShowLandmarks(true)}>
+                <Text style={styles.showMoreText}>+{(data?.landmarks?.length || 0) - 3}개 더 보기</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+
+        <TouchableOpacity
+          style={styles.startButton}
+          onPress={() => {
+            const targetDistanceKm = parseFloat(String(data?.distance ?? '0')) || 0;
+            navigation?.navigate?.('LiveRunningScreen', { targetDistanceKm });
+          }}
+        >
+          <Text style={styles.startButtonText}>여정 계속하기</Text>
+        </TouchableOpacity>
+      </ScrollView>
+
+      <Modal visible={showLandmarks} animationType="slide" presentationStyle="pageSheet">
+        <View style={styles.modalContainer}>
+          <View style={styles.modalHeader}>
+            <Text style={styles.modalTitle}>주요 랜드마크</Text>
+            <TouchableOpacity style={styles.closeButton} onPress={() => setShowLandmarks(false)}>
+              <Text style={styles.closeIcon}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView style={styles.modalContent}>
+            {(data?.landmarks || []).map((lm, idx) => (
+              <View key={lm.id} style={styles.modalLandmarkItem}>
+                <View style={[styles.landmarkNumber, lm.completed && styles.completedLandmarkNumber]}>
+                  <Text style={[styles.landmarkNumberText, lm.completed && styles.completedLandmarkNumberText]}>{lm.completed ? '✓' : idx + 1}</Text>
+                </View>
+                <View style={styles.landmarkInfo}>
+                  <Text style={[styles.landmarkName, lm.completed && styles.completedLandmarkName]}>{lm.name}</Text>
+                  <Text style={styles.landmarkDistance}>{lm.distance}</Text>
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+
+          <TouchableOpacity
+            style={styles.modalStartButton}
+            onPress={() => {
+              setShowLandmarks(false);
+              const targetDistanceKm = parseFloat(String(data?.distance ?? '0')) || 0;
+              navigation?.navigate?.('LiveRunningScreen', { targetDistanceKm });
+            }}
+          >
+            <Text style={styles.modalStartButtonText}>여정 계속하기</Text>
+          </TouchableOpacity>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#FFFFFF' },
+  headerContainer: { height: 300, backgroundColor: '#1F2937', position: 'relative', justifyContent: 'center', alignItems: 'center' },
+  backButton: { position: 'absolute', top: 60, left: 20, width: 40, height: 40, borderRadius: 20, backgroundColor: 'rgba(0, 0, 0, 0.3)', alignItems: 'center', justifyContent: 'center' },
+  backIcon: { color: '#FFFFFF', fontSize: 18, fontWeight: '600' },
+  menuButton: { position: 'absolute', top: 60, right: 20, width: 40, height: 40, borderRadius: 20, backgroundColor: 'rgba(0, 0, 0, 0.3)', alignItems: 'center', justifyContent: 'center' },
+  menuIcon: { color: '#FFFFFF', fontSize: 18, fontWeight: '600' },
+  headerContent: { alignItems: 'center' },
+  headerTitle: { color: '#FFFFFF', fontSize: 22, fontWeight: '800', marginBottom: 8 },
+  headerBadge: { backgroundColor: 'rgba(255,255,255,0.16)', borderRadius: 12, paddingHorizontal: 10, paddingVertical: 4 },
+  headerBadgeText: { color: '#FFFFFF', fontSize: 12, fontWeight: '700' },
+  headerImagePlaceholder: { position: 'absolute', bottom: 16, right: 20 },
+  headerImageIcon: { fontSize: 40 },
+  content: { flex: 1 },
+  infoCard: { margin: 16, backgroundColor: '#FFFFFF', borderRadius: 12, padding: 16, shadowColor: '#000', shadowOpacity: 0.06, shadowRadius: 8, shadowOffset: { width: 0, height: 2 }, elevation: 1 },
+  sectionTitle: { fontSize: 16, fontWeight: '800', color: '#111827', marginBottom: 8 },
+  description: { fontSize: 14, color: '#6B7280', lineHeight: 20, marginBottom: 12 },
+  landmarksPreview: {},
+  landmarkItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10 },
+  landmarkNumber: { width: 28, height: 28, borderRadius: 14, backgroundColor: '#EEF2FF', alignItems: 'center', justifyContent: 'center', marginRight: 10 },
+  landmarkNumberText: { color: '#6366F1', fontWeight: '800' },
+  landmarkInfo: { flex: 1 },
+  landmarkName: { fontSize: 14, color: '#111827', fontWeight: '700' },
+  landmarkDistance: { fontSize: 12, color: '#6B7280' },
+  completedBadge: { backgroundColor: '#10B981', borderRadius: 12, paddingHorizontal: 8, paddingVertical: 2 },
+  completedIcon: { color: '#fff', fontWeight: '800' },
+  showMoreButton: { marginTop: 8, backgroundColor: '#EEF2FF', borderRadius: 10, paddingVertical: 10, alignItems: 'center' },
+  showMoreText: { color: '#6366F1', fontWeight: '700' },
+  startButton: { margin: 16, backgroundColor: '#6366F1', borderRadius: 12, paddingVertical: 16, alignItems: 'center' },
+  startButtonText: { color: '#fff', fontSize: 16, fontWeight: '800' },
+  modalContainer: { flex: 1, backgroundColor: '#fff' },
+  modalHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 14, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: '#E5E7EB' },
+  modalTitle: { fontSize: 16, fontWeight: '800', color: '#111827' },
+  closeButton: { position: 'absolute', right: 12, top: 10, padding: 8 },
+  closeIcon: { fontSize: 16, color: '#6B7280' },
+  modalContent: { paddingHorizontal: 16 },
+  modalLandmarkItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: 12 },
+  completedLandmarkNumber: { backgroundColor: '#10B981' },
+  completedLandmarkNumberText: { color: '#fff', fontWeight: '800' },
+  completedLandmarkName: { color: '#10B981' },
+  modalStartButton: { margin: 16, backgroundColor: '#6366F1', borderRadius: 12, paddingVertical: 16, alignItems: 'center' },
+  modalStartButtonText: { color: '#fff', fontSize: 16, fontWeight: '800' },
+});

--- a/Pages/JourneyRouteListScreen.tsx
+++ b/Pages/JourneyRouteListScreen.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, StatusBar } from 'react-native';
+import useRouteList from "../hooks/journey/useJourneyRouteList";
+import type { RouteSummary } from "../utils/api/journeyRoutes";
+
+export default function RouteListScreen({ navigation }: any) {
+  const [activeTab, setActiveTab] = useState('전체');
+  const { data: routes, loading } = useRouteList();
+
+  const tabs = ['전체', '국내 여행', '해외 여행'];
+
+  const getDifficultyColor = (difficulty: string) => {
+    switch (difficulty) {
+      case '쉬움':
+        return '#10B981';
+      case '보통':
+        return '#F59E0B';
+      case '어려움':
+        return '#EF4444';
+      default:
+        return '#6B7280';
+    }
+  };
+
+  const getProgressPercentage = (completed: number, total: number) => {
+    return total > 0 ? Math.round((completed / total) * 100) : 0;
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="dark-content" backgroundColor="#FFFFFF" />
+
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>여정 리스트</Text>
+
+        <View style={styles.tabContainer}>
+          {tabs.map((tab) => (
+            <TouchableOpacity key={tab} style={[styles.tab, activeTab === tab && styles.activeTab]} onPress={() => setActiveTab(tab)}>
+              <Text style={[styles.tabText, activeTab === tab && styles.activeTabText]}>{tab}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        {loading && (
+          <Text style={{ padding: 16, color: '#6B7280' }}>로딩 중...</Text>
+        )}
+        {(routes || []).map((route: RouteSummary) => (
+          <TouchableOpacity
+            key={route.id}
+            style={styles.routeCard}
+            onPress={() => navigation?.navigate?.('JourneyRouteDetail', { id: route.id })}
+          >
+            <View style={styles.routeImageContainer}>
+              <View style={styles.routeImage}>
+                <Text style={styles.routeImagePlaceholder}>
+                  {route.image === 'palace' ? '🏯' : route.image === 'jeju' ? '🏝️' : '🌉'}
+                </Text>
+              </View>
+              <View style={styles.progressBadge}>
+                <Text style={styles.progressText}>{getProgressPercentage(route.completed, route.total)}% 완료</Text>
+              </View>
+              <TouchableOpacity style={styles.favoriteButton}>
+                <Text style={styles.favoriteIcon}>역사 탐방</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.routeInfo}>
+              <Text style={styles.routeTitle}>{route.title}</Text>
+              <Text style={styles.routeDescription} numberOfLines={3}>
+                {route.description}
+              </Text>
+
+              <View style={styles.routeTags}>
+                {route.tags.map((tag, index) => (
+                  <View key={`${route.id}-tag-${index}`} style={styles.tag}>
+                    <Text style={styles.tagText}>{tag}</Text>
+                  </View>
+                ))}
+              </View>
+
+              <View style={styles.routeStats}>
+                <View style={styles.statItem}>
+                  <Text style={styles.statValue}>{route.distance}</Text>
+                </View>
+                <View style={styles.statItem}>
+                  <Text style={styles.statValue}>{route.duration}</Text>
+                </View>
+                <View style={styles.statItem}>
+                  <Text style={[styles.statValue, { color: getDifficultyColor(route.difficulty) }]}>{route.difficulty}</Text>
+                </View>
+              </View>
+
+              <Text style={styles.participantCount}>
+                함께한 러너 {route.total.toLocaleString()}명
+                <Text style={styles.completedCount}> ▶ 8개 랜드마크</Text>
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F9FAFB' },
+  header: { backgroundColor: '#FFFFFF', paddingHorizontal: 20, paddingTop: 16, paddingBottom: 12, borderBottomWidth: 1, borderBottomColor: '#F3F4F6' },
+  headerTitle: { fontSize: 18, fontWeight: 'bold', color: '#111827', marginBottom: 16 },
+  tabContainer: { flexDirection: 'row' },
+  tab: { paddingHorizontal: 12, paddingVertical: 8, marginRight: 8, borderRadius: 20 },
+  activeTab: { backgroundColor: '#EEF2FF' },
+  tabText: { fontSize: 14, color: '#6B7280', fontWeight: '500' },
+  activeTabText: { color: '#6366F1', fontWeight: '600' },
+  content: { flex: 1, paddingHorizontal: 20 },
+  routeCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    marginTop: 16,
+    overflow: 'hidden',
+    elevation: 2,
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+  },
+  routeImageContainer: { height: 200, backgroundColor: '#1F2937', position: 'relative', justifyContent: 'center', alignItems: 'center' },
+  routeImage: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  routeImagePlaceholder: { fontSize: 48 },
+  progressBadge: { position: 'absolute', top: 12, left: 12, backgroundColor: 'rgba(0, 0, 0, 0.7)', borderRadius: 12, paddingHorizontal: 8, paddingVertical: 4 },
+  progressText: { color: '#FFFFFF', fontSize: 12, fontWeight: '600' },
+  favoriteButton: { position: 'absolute', top: 12, right: 12, backgroundColor: '#6366F1', borderRadius: 12, paddingHorizontal: 8, paddingVertical: 4 },
+  favoriteIcon: { color: '#FFFFFF', fontSize: 12, fontWeight: '600' },
+  routeInfo: { padding: 16 },
+  routeTitle: { fontSize: 18, fontWeight: 'bold', color: '#111827', marginBottom: 8 },
+  routeDescription: { fontSize: 14, color: '#6B7280', lineHeight: 20, marginBottom: 12 },
+  routeTags: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 12 },
+  tag: { backgroundColor: '#EEF2FF', borderRadius: 12, paddingHorizontal: 8, paddingVertical: 4, marginRight: 8, marginBottom: 4 },
+  tagText: { fontSize: 12, color: '#6366F1', fontWeight: '500' },
+  routeStats: { flexDirection: 'row', marginBottom: 8 },
+  statItem: { marginRight: 16 },
+  statValue: { fontSize: 14, fontWeight: '600', color: '#374151' },
+  participantCount: { fontSize: 12, color: '#9CA3AF' },
+  completedCount: { color: '#6366F1', fontWeight: '500' },
+});

--- a/Pages/LiveRunningScreen.tsx
+++ b/Pages/LiveRunningScreen.tsx
@@ -20,7 +20,8 @@ import BottomNavigation from "../components/Layout/BottomNav";
 import { useBottomNav } from "../hooks/useBottomNav";
 import { apiComplete } from "../utils/api/running"; // ✅ 추가
 
-export default function LiveRunningScreen({ navigation }: { navigation: any }) {
+export default function LiveRunningScreen({ navigation, route }: { navigation: any; route?: any }) {
+  const targetDistanceKm = (route?.params?.targetDistanceKm as number | undefined) ?? undefined;
   const { activeTab, onTabPress } = useBottomNav("running");
   const t = useLiveRunTracker();
   const insets = useSafeAreaInsets();
@@ -127,6 +128,53 @@ export default function LiveRunningScreen({ navigation }: { navigation: any }) {
       return null;
     }
   };
+
+  const completeRun = useCallback(async () => {
+    if (isStoppingRef.current) return;
+    isStoppingRef.current = true;
+    try {
+      const avgPaceSec =
+        t.distance > 0 && Number.isFinite(t.elapsedSec / t.distance)
+          ? Math.floor(t.elapsedSec / Math.max(t.distance, 0.000001))
+          : null;
+      const routePoints = t.route.map((p, i) => ({ latitude: p.latitude, longitude: p.longitude, sequence: i + 1 }));
+      const { runId } = await apiComplete({
+        sessionId: t.sessionId as string,
+        distanceMeters: Math.round(t.distance * 1000),
+        durationSeconds: t.elapsedSec,
+        averagePaceSeconds: avgPaceSec,
+        calories: Math.round(t.kcal),
+        routePoints,
+        endedAt: Date.now(),
+        title: "오늘의 러닝",
+      });
+      t.stop();
+      navigation.navigate("RunSummary", {
+        runId,
+        defaultTitle: "오늘의 러닝",
+        distanceKm: t.distance,
+        paceLabel: t.paceLabel,
+        kcal: Math.round(t.kcal),
+        elapsedSec: t.elapsedSec,
+        elapsedLabel: `${Math.floor(t.elapsedSec / 60)}:${String(t.elapsedSec % 60).padStart(2, "0")}`,
+        routePath: t.route,
+        sessionId: (t.sessionId as string) ?? "",
+      });
+    } catch (e) {
+      console.error("러닝 완료/저장 실패:", e);
+      Alert.alert("저장 실패", "네트워크 또는 서버 오류가 발생했어요.");
+    } finally {
+      setTimeout(() => (isStoppingRef.current = false), 800);
+    }
+  }, [navigation, t]);
+
+  React.useEffect(() => {
+    if (!targetDistanceKm) return;
+    if (!t.isRunning) return;
+    if (t.distance >= targetDistanceKm) {
+      completeRun();
+    }
+  }, [t.distance, t.isRunning, targetDistanceKm, completeRun]);
 
   return (
     <SafeLayout withBottomInset>
@@ -281,7 +329,7 @@ export default function LiveRunningScreen({ navigation }: { navigation: any }) {
               <Pressable
                 onPress={() => {
                   closeMenu();
-                  Alert.alert("가상 러닝", "가상 러닝 화면 연결 예정!");
+                  navigation.navigate("JourneyLoading");
                 }}
                 style={{
                   width: 100,
@@ -292,10 +340,8 @@ export default function LiveRunningScreen({ navigation }: { navigation: any }) {
                   justifyContent: "center",
                 }}
               >
-                <Text
-                  style={{ fontSize: 16, fontWeight: "800", color: "#111" }}
-                >
-                  가상 러닝
+                <Text style={{ fontSize: 16, fontWeight: "800", color: "#111" }}>
+                  여정 러닝
                 </Text>
               </Pressable>
             </Animated.View>
@@ -335,54 +381,7 @@ export default function LiveRunningScreen({ navigation }: { navigation: any }) {
           onPause={() => t.pause()}
           onResume={() => t.resume()}
           onStopTap={() => Alert.alert("종료하려면 길게 누르세요")}
-          onStopLong={async () => {
-            if (isStoppingRef.current) return;
-            isStoppingRef.current = true;
-            try {
-              // 지도 스냅샷은 더 이상 공유 사진으로 사용하지 않음
-
-              const avgPaceSec =
-                t.distance > 0 && Number.isFinite(t.elapsedSec / t.distance)
-                  ? Math.floor(t.elapsedSec / Math.max(t.distance, 0.000001))
-                  : null;
-
-              const routePoints = t.route.map((p, i) => ({
-                latitude: p.latitude,
-                longitude: p.longitude,
-                sequence: i + 1,
-              }));
-
-              const { runId } = await apiComplete({
-                sessionId: t.sessionId as string,
-                distanceMeters: Math.round(t.distance * 1000),
-                durationSeconds: t.elapsedSec,
-                averagePaceSeconds: avgPaceSec,
-                calories: Math.round(t.kcal),
-                routePoints,
-                endedAt: Date.now(),
-                title: "오늘의 러닝",
-              });
-
-              t.stop();
-
-              navigation.navigate("RunSummary", {
-                runId,
-                defaultTitle: "오늘의 러닝",
-                distanceKm: t.distance,
-                paceLabel: t.paceLabel,
-                kcal: Math.round(t.kcal),
-                elapsedSec: t.elapsedSec,
-                elapsedLabel: `${Math.floor(t.elapsedSec/60)}:${String(t.elapsedSec%60).padStart(2,'0')}`,
-                routePath: t.route,
-                sessionId: (t.sessionId as string) ?? "",
-              });
-            } catch (e) {
-              console.error("러닝 완료/저장 실패:", e);
-              Alert.alert("저장 실패", "네트워크 또는 서버 오류가 발생했어요.");
-            } finally {
-              setTimeout(() => (isStoppingRef.current = false), 800);
-            }
-          }}
+          onStopLong={completeRun}
         />
       )}
 

--- a/Pages/LoadingScreen.tsx
+++ b/Pages/LoadingScreen.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Animated, Dimensions, StatusBar } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const { width, height } = Dimensions.get('window');
+
+type LoadingScreenProps = { onLoadingComplete?: () => void; navigation?: any };
+
+const LoadingScreen: React.FC<LoadingScreenProps> = ({ onLoadingComplete, navigation }) => {
+  const [progress] = useState(new Animated.Value(0));
+  const [loadingText, setLoadingText] = useState('앱을 로딩하고 있습니다..');
+
+  useEffect(() => {
+    const loadingTexts = ['앱을 로딩하고 있습니다.', '앱을 로딩하고 있습니다..', '앱을 로딩하고 있습니다...'];
+
+    let textIndex = 0;
+    const textInterval = setInterval(() => {
+      textIndex = (textIndex + 1) % loadingTexts.length;
+      setLoadingText(loadingTexts[textIndex]);
+    }, 500);
+
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: 3000,
+      useNativeDriver: false,
+    }).start(() => {
+      clearInterval(textInterval);
+      setTimeout(async () => {
+        try {
+          const token = await AsyncStorage.getItem('jwtToken');
+          if (token) {
+            navigation?.reset?.({ index: 0, routes: [{ name: 'Main' }] });
+          } else {
+            navigation?.reset?.({ index: 0, routes: [{ name: 'Login' }] });
+          }
+        } catch {
+          navigation?.reset?.({ index: 0, routes: [{ name: 'Login' }] });
+        }
+      }, 500);
+    });
+
+    return () => clearInterval(textInterval);
+  }, [onLoadingComplete, progress, navigation]);
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" backgroundColor="#6366F1" />
+      <LinearGradient colors={['#8B5CF6', '#6366F1']} style={styles.gradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}>
+        <View style={styles.content}>
+          <Text style={styles.logo}>로그</Text>
+
+          <View style={styles.titleContainer}>
+            <Text style={styles.title}>주제목</Text>
+            <Text style={styles.subtitle}>
+              달리며 떠나는 특별한 여행{"\n"}
+              세계 곳곳의 아름다운 여정을 경험하세요
+            </Text>
+          </View>
+
+          <View style={styles.loadingContainer}>
+            <View style={styles.progressBarContainer}>
+              <Animated.View
+                style={[
+                  styles.progressBar,
+                  {
+                    width: progress.interpolate({ inputRange: [0, 1], outputRange: ['0%', '100%'] }),
+                  },
+                ]}
+              />
+            </View>
+            <Text style={styles.loadingText}>{loadingText}</Text>
+          </View>
+        </View>
+      </LinearGradient>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  gradient: { flex: 1 },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 40,
+    paddingTop: height * 0.15,
+    paddingBottom: height * 0.1,
+  },
+  logo: { fontSize: 18, color: '#FFFFFF', fontWeight: '600', letterSpacing: 1 },
+  titleContainer: { alignItems: 'center', flex: 1, justifyContent: 'center' },
+  title: { fontSize: 32, fontWeight: 'bold', color: '#FFFFFF', marginBottom: 20, letterSpacing: -0.5 },
+  subtitle: { fontSize: 16, color: '#E0E7FF', textAlign: 'center', lineHeight: 24, opacity: 0.9 },
+  loadingContainer: { alignItems: 'center', width: '100%' },
+  progressBarContainer: {
+    width: width * 0.6,
+    height: 4,
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    borderRadius: 2,
+    marginBottom: 16,
+    overflow: 'hidden',
+  },
+  progressBar: { height: '100%', backgroundColor: '#FFFFFF', borderRadius: 2 },
+  loadingText: { fontSize: 14, color: '#E0E7FF', opacity: 0.8 },
+});
+
+export default LoadingScreen;

--- a/Pages/Main.tsx
+++ b/Pages/Main.tsx
@@ -92,7 +92,7 @@ export default function Main() {
 
   const goVirtualRun = () => {
     closeMenu();
-    nav.navigate("VirtualRunning"); // 필요 시 다른 화면
+    nav.navigate("JourneyLoading");
   };
 
   return (
@@ -128,7 +128,7 @@ export default function Main() {
           </Pressable>
         </Animated.View>
 
-        {/* 오른쪽: 가상 러닝 */}
+        {/* 오른쪽: 여정 러닝 */}
         <Animated.View
           style={[
             s.smallFab,
@@ -143,7 +143,7 @@ export default function Main() {
           ]}
         >
           <Pressable style={s.smallFabBtn} onPress={goVirtualRun}>
-            <Text style={s.smallFabText}>가상 러닝</Text>
+            <Text style={s.smallFabText}>여정 러닝</Text>
           </Pressable>
         </Animated.View>
 

--- a/Pages/OnboardingScreen.tsx
+++ b/Pages/OnboardingScreen.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  StatusBar,
+  Dimensions,
+} from "react-native";
+
+const { height } = Dimensions.get("window");
+
+type OnboardingScreenProps = {
+  onStart?: () => void;
+  onSkip?: () => void;
+  navigation?: any;
+};
+
+const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
+  onStart,
+  onSkip,
+  navigation,
+}) => {
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="dark-content" backgroundColor="#FFFFFF" />
+
+      <View style={styles.content}>
+        <Text style={styles.title}>
+          [ 주제목 ] 에{"\n"}오신 것을 환영합니다!
+        </Text>
+
+        <View style={styles.featuresContainer}>
+          <Text style={styles.sectionTitle}>함영 부 목구</Text>
+          <Text style={styles.description}>
+            역사적 명소의 지인 경로를 달리며 탐험
+          </Text>
+
+          <View style={styles.featuresList}>
+            <View style={styles.featureItem}>
+              <Text style={styles.featureIcon}>🏆</Text>
+              <Text style={styles.featureText}>
+                랜드마크 도달 시 기념 스탬프 수집
+              </Text>
+            </View>
+
+            <View style={styles.featureItem}>
+              <Text style={styles.featureIcon}>👥</Text>
+              <Text style={styles.featureText}>
+                다른 러너들과 방명록으로 소통
+              </Text>
+            </View>
+
+            <View style={styles.featureItem}>
+              <Text style={styles.featureIcon}>🏛️</Text>
+              <Text style={styles.featureText}>
+                각 장소의 흥미로운 스토리 가이드
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            style={styles.startButton}
+            onPress={
+              onStart ??
+              (() =>
+                navigation?.reset?.({
+                  index: 0,
+                  routes: [{ name: "JourneyLoading" }],
+                }))
+            }
+          >
+            <Text style={styles.startButtonText}>시작하기</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.skipButton}
+            onPress={
+              onSkip ??
+              (() =>
+                navigation?.reset?.({ index: 0, routes: [{ name: "Main" }] }))
+            }
+          >
+            <Text style={styles.skipButtonText}>다시보지 않기</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#FFFFFF" },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: height * 0.1,
+    paddingBottom: 40,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: "#1F2937",
+    textAlign: "center",
+    marginBottom: 60,
+    lineHeight: 32,
+  },
+  featuresContainer: { flex: 1, alignItems: "center" },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#6B7280",
+    marginBottom: 12,
+  },
+  description: {
+    fontSize: 14,
+    color: "#9CA3AF",
+    textAlign: "center",
+    marginBottom: 40,
+    lineHeight: 20,
+  },
+  featuresList: { width: "100%" },
+  featureItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 24,
+    paddingHorizontal: 16,
+  },
+  featureIcon: { fontSize: 24, marginRight: 16, width: 32 },
+  featureText: { fontSize: 16, color: "#374151", flex: 1, lineHeight: 22 },
+  buttonContainer: { width: "100%" },
+  startButton: {
+    backgroundColor: "#6366F1",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  startButtonText: { fontSize: 16, fontWeight: "600", color: "#FFFFFF" },
+  skipButton: {
+    backgroundColor: "transparent",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+  },
+  skipButtonText: { fontSize: 16, fontWeight: "500", color: "#6B7280" },
+});
+
+export default OnboardingScreen;

--- a/components/Running/ArcMenu.tsx
+++ b/components/Running/ArcMenu.tsx
@@ -5,7 +5,7 @@ export default function ArcMenu({
   open,
   radius = 96,
   leftLabel = "러닝",
-  rightLabel = "가상 러닝",
+  rightLabel = "여정 러닝",
   onLeftPress,
   onRightPress,
   containerStyle,

--- a/hooks/journey/useJourneyRouteDetail.ts
+++ b/hooks/journey/useJourneyRouteDetail.ts
@@ -1,0 +1,28 @@
+// hooks/routes/useRouteDetail.ts
+import { useEffect, useState } from 'react';
+import { getRouteDetail, type RouteDetail, type RouteId } from '../../utils/api/journeyRoutes';
+
+export default function useRouteDetail(id: RouteId | undefined) {
+  const [data, setData] = useState<RouteDetail | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!id) {
+      setError(new Error('invalid route id'));
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    getRouteDetail(id)
+      .then((res) => mounted && setData(res))
+      .catch((e) => mounted && setError(e as Error))
+      .finally(() => mounted && setLoading(false));
+    return () => {
+      mounted = false;
+    };
+  }, [id]);
+
+  return { data, loading, error } as const;
+}

--- a/hooks/journey/useJourneyRouteList.ts
+++ b/hooks/journey/useJourneyRouteList.ts
@@ -1,0 +1,25 @@
+// hooks/routes/useRouteList.ts
+import { useEffect, useState } from 'react';
+import { listRoutes, type RouteSummary } from '../../utils/api/journeyRoutes';
+
+export default function useRouteList() {
+  const [data, setData] = useState<RouteSummary[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    listRoutes()
+      .then((res) => {
+        if (mounted) setData(res);
+      })
+      .catch((e) => mounted && setError(e as Error))
+      .finally(() => mounted && setLoading(false));
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { data, loading, error } as const;
+}

--- a/types/journey.ts
+++ b/types/journey.ts
@@ -1,0 +1,81 @@
+// types/journey.ts
+// 여정(코스) 도메인 타입 정의 (목/실서버 공통 사용)
+
+export type JourneyId = string;
+export type LandmarkOrder = number;
+
+export type JourneyCategory = "nature" | "city" | "mountain" | "coast" | "custom";
+export type JourneyDifficulty = "beginner" | "intermediate" | "advanced";
+
+export interface Journey {
+  id: JourneyId;
+  title: string;
+  category: JourneyCategory;
+  difficulty: JourneyDifficulty;
+  totalKm: number;
+  highlights: string[];
+  coverImage?: string;
+  stampsRequired?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface LatLngPoint {
+  lat: number;
+  lng: number;
+}
+
+export interface Landmark {
+  id: string;
+  journeyId: JourneyId;
+  order: LandmarkOrder;
+  name: string;
+  desc?: string;
+  image?: string;
+  pos: LatLngPoint; // 원본 좌표
+  anchor: LatLngPoint; // 도로 스냅/앵커 좌표(경로 강제용)
+  radiusM: number; // 체크인 반경
+}
+
+export interface Segment {
+  id: string;
+  journeyId: JourneyId;
+  orderFrom: LandmarkOrder;
+  orderTo: LandmarkOrder;
+  distanceM: number;
+  polylineEncoded?: string;
+  elevationGainM?: number;
+}
+
+export interface JourneyStats {
+  journeyId: JourneyId;
+  finishers: number;
+  avgRating: number; // 0~5
+  totalCheckins: number;
+  lastAggregatedAt?: string;
+}
+
+export interface UserJourneyState {
+  userId: string;
+  journeyId: JourneyId;
+  progressM: number;
+  lastLandmarkOrder: LandmarkOrder;
+  runsCount: number;
+  startedAt: string;
+  completedAt?: string | null;
+}
+
+export interface Stamp {
+  id: string;
+  journeyId: JourneyId;
+  landmarkId: string;
+  userId: string;
+  mood?: string;
+  rating?: number; // 1~5
+  text?: string;
+  photos?: string[];
+  likes?: number;
+  reports?: number;
+  createdAt: string;
+}
+

--- a/utils/api/journeyRoutes.ts
+++ b/utils/api/journeyRoutes.ts
@@ -1,0 +1,95 @@
+// utils/api/journeyRoutes.ts
+// Mock API for Journey routes (virtual journeys)
+
+export type RouteId = string;
+
+export type RouteSummary = {
+  id: RouteId;
+  title: string;
+  description: string;
+  distance: string; // e.g., '42.5Km'
+  duration: string; // e.g., '28일'
+  difficulty: '쉬움' | '보통' | '어려움' | string;
+  completed: number;
+  total: number;
+  image: 'palace' | 'jeju' | 'hangang' | string;
+  tags: string[];
+};
+
+export type Landmark = { id: string; name: string; distance: string; completed?: boolean };
+
+export type RouteDetail = RouteSummary & {
+  landmarks: Landmark[];
+};
+
+const mockRoutes: RouteDetail[] = [
+  {
+    id: '1',
+    title: '한국의 고궁탐방',
+    description:
+      '조선왕조의 아름다운 궁궐들을 달리며 만나보세요. 경복궁에서 시작하여 창덕궁, 창경궁, 덕수궁까지 이어지는 역사의 여정입니다.',
+    distance: '42.5Km',
+    duration: '28일',
+    difficulty: '보통',
+    completed: 1,
+    total: 234,
+    image: 'palace',
+    tags: ['경복궁', '창덕궁', '덕수궁'],
+    landmarks: [
+      { id: '1-1', name: '경복궁', distance: '8.5km 지점', completed: true },
+      { id: '1-2', name: '창덕궁', distance: '15.2km 지점' },
+      { id: '1-3', name: '창경궁', distance: '23.1km 지점' },
+      { id: '1-4', name: '종묘', distance: '31.5km 지점' },
+      { id: '1-5', name: '덕수궁', distance: '42.5km 지점' },
+    ],
+  },
+  {
+    id: '2',
+    title: '제주 올레길 완주',
+    description: '제주의 아름다운 자연과 함께하는 특별한 여정',
+    distance: '425Km',
+    duration: '60일',
+    difficulty: '어려움',
+    completed: 0,
+    total: 156,
+    image: 'jeju',
+    tags: ['성산일출봉', '우도', '한라산'],
+    landmarks: [
+      { id: '2-1', name: '성산일출봉', distance: '12.0km 지점' },
+      { id: '2-2', name: '우도', distance: '84.3km 지점' },
+      { id: '2-3', name: '한라산', distance: '201.0km 지점' },
+    ],
+  },
+  {
+    id: '3',
+    title: '서울 한강 종주',
+    description: '한강을 따라 서울의 모든 다리를 지나는 도심 여정',
+    distance: '50.2Km',
+    duration: '15일',
+    difficulty: '쉬움',
+    completed: 0,
+    total: 312,
+    image: 'hangang',
+    tags: ['반포대교', '동작대교', '한강공원'],
+    landmarks: [
+      { id: '3-1', name: '반포대교', distance: '5.0km 지점' },
+      { id: '3-2', name: '동작대교', distance: '12.0km 지점' },
+      { id: '3-3', name: '여의도 한강공원', distance: '20.0km 지점' },
+    ],
+  },
+];
+
+const wait = (ms = 200) => new Promise((r) => setTimeout(r, ms));
+
+export async function listRoutes(): Promise<RouteSummary[]> {
+  await wait();
+  return mockRoutes.map(({ landmarks, ...rest }) => rest);
+}
+
+export async function getRouteDetail(id: RouteId): Promise<RouteDetail> {
+  await wait();
+  const found = mockRoutes.find((r) => r.id === id);
+  if (!found) throw new Error('Route not found');
+  return found;
+}
+

--- a/utils/api/stamps.ts
+++ b/utils/api/stamps.ts
@@ -1,0 +1,57 @@
+// utils/api/stamps.ts
+// 스탬프/방명록 목 API
+import type { JourneyId } from "../../types/journey";
+
+type ClaimBody = {
+  journeyId: JourneyId;
+  landmarkId: string;
+  userLat: number;
+  userLng: number;
+  photo?: string;
+  mood?: string;
+  rating?: number;
+  text?: string;
+};
+
+export async function claimStamp(body: ClaimBody) {
+  await new Promise((r) => setTimeout(r, 120));
+  // 목: 위치 반경은 클라 선검사에 맡기고 항상 성공 처리
+  return {
+    granted: true,
+    stampId: `st_${Date.now()}`,
+    newTotalStamps: Math.floor(Math.random() * 10) + 1,
+  };
+}
+
+export async function getGuestbook(journeyId: JourneyId, landmarkId?: string) {
+  await new Promise((r) => setTimeout(r, 120));
+  return [
+    {
+      id: "gb_1",
+      user: "지구러너",
+      text: "경치가 최고!",
+      rating: 5,
+      likes: 3,
+      createdAt: new Date().toISOString(),
+    },
+  ];
+}
+
+export async function postGuestbook(
+  journeyId: JourneyId,
+  data: { landmarkId?: string; text: string; rating?: number }
+) {
+  await new Promise((r) => setTimeout(r, 120));
+  return { id: `gb_${Date.now()}`, ...data };
+}
+
+export async function likeGuestbook(id: string) {
+  await new Promise((r) => setTimeout(r, 80));
+  return { ok: true };
+}
+
+export async function reportGuestbook(id: string) {
+  await new Promise((r) => setTimeout(r, 80));
+  return { ok: true };
+}
+

--- a/utils/api/userJourneys.ts
+++ b/utils/api/userJourneys.ts
@@ -1,0 +1,94 @@
+// utils/api/userJourneys.ts
+// 유저별 여정 진행 상태 목 API
+import type { JourneyId, UserJourneyState } from "../../types/journey";
+
+type ProgressResponse = {
+  progressM: number;
+  lastLandmarkOrder: number;
+  nextLandmarkDistM: number;
+  percent: number;
+  todayRunM: number;
+  message: string;
+};
+
+const stateByUserJourney = new Map<string, UserJourneyState>();
+const todayByUserJourney = new Map<string, number>(); // 간단 today delta 저장
+
+function key(userId: string, journeyId: JourneyId) {
+  return `${userId}::${journeyId}`;
+}
+
+function wait(ms = 150) {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+export async function start(userId: string, journeyId: JourneyId): Promise<UserJourneyState> {
+  await wait();
+  const k = key(userId, journeyId);
+  const now = new Date().toISOString();
+  const existing = stateByUserJourney.get(k);
+  if (existing) return existing;
+  const s: UserJourneyState = {
+    userId,
+    journeyId,
+    progressM: 0,
+    lastLandmarkOrder: 0,
+    runsCount: 0,
+    startedAt: now,
+    completedAt: null,
+  };
+  stateByUserJourney.set(k, s);
+  todayByUserJourney.set(k, 0);
+  return s;
+}
+
+export async function getState(
+  userId: string,
+  journeyId: JourneyId,
+  totalM: number,
+  nextLandmarkDistM: number
+): Promise<ProgressResponse> {
+  await wait();
+  const k = key(userId, journeyId);
+  const s = stateByUserJourney.get(k);
+  const today = todayByUserJourney.get(k) ?? 0;
+  const progressM = s?.progressM ?? 0;
+  const percent = totalM > 0 ? Math.min(100, (progressM / totalM) * 100) : 0;
+  return {
+    progressM,
+    lastLandmarkOrder: s?.lastLandmarkOrder ?? 0,
+    nextLandmarkDistM,
+    percent,
+    todayRunM: today,
+    message: `오늘 ${(today / 1000).toFixed(2)}km를 뛰어 총 ${(progressM / 1000).toFixed(2)}km 진행`,
+  };
+}
+
+export async function progress(
+  userId: string,
+  journeyId: JourneyId,
+  totalM: number,
+  deltaM: number
+): Promise<ProgressResponse> {
+  await wait();
+  const k = key(userId, journeyId);
+  const s = stateByUserJourney.get(k);
+  if (!s) throw new Error("journey not started");
+  const newProgress = Math.min(totalM, Math.max(0, (s.progressM ?? 0) + Math.max(0, deltaM)));
+  s.progressM = newProgress;
+  s.runsCount += 1;
+  stateByUserJourney.set(k, s);
+  const today = (todayByUserJourney.get(k) ?? 0) + Math.max(0, deltaM);
+  todayByUserJourney.set(k, today);
+  const percent = totalM > 0 ? Math.min(100, (newProgress / totalM) * 100) : 0;
+  const remaining = Math.max(0, totalM - newProgress);
+  return {
+    progressM: newProgress,
+    lastLandmarkOrder: s.lastLandmarkOrder,
+    nextLandmarkDistM: remaining, // 간소화(실제는 세그먼트별 계산)
+    percent,
+    todayRunM: today,
+    message: `오늘 ${(today / 1000).toFixed(2)}km를 뛰어 총 ${(newProgress / 1000).toFixed(2)}km 진행`,
+  };
+}
+

--- a/utils/run.ts
+++ b/utils/run.ts
@@ -23,7 +23,8 @@ export const avgPaceSecPerKm = (distanceKm: number, elapsedSec: number) => {
   if (!isFinite(distanceKm) || distanceKm < 0.05) return Infinity;
   if (!isFinite(elapsedSec) || elapsedSec <= 0) return Infinity;
   const secPerKm = elapsedSec / distanceKm;
-  return Math.floor(secPerKm); // 반올림 대신 내림 → 과대 계산 방지
+  // 닉런과 유사한 표기: 초 단위 반올림
+  return Math.round(secPerKm);
 };
 
 // 라벨 변환


### PR DESCRIPTION
# feat: 여정(Journey) 타입/API/훅/스크린 추가 및 라이브 러닝 개선

## 요약
여정 기능(타입, API, 훅, 스크린)을 추가하고 라이브 러닝 트래커와 ArcMenu 동작을 개선합니다.

## 변경 사항
- 타입: `Journey` 관련 타입 추가
- API: `journeyRoutes`, `userJourneys`, `stamps` 클라이언트 추가
- 훅: `useJourneyRouteList`, `useJourneyRouteDetail` 추가
- 스크린: 라우트 리스트/디테일, 가이드, 로딩, 온보딩, 게스트북 추가
- 앱 셸: `App.tsx` / `Pages/Main.tsx`에 여정 라우트 연결
- 러닝: `LiveRunningScreen`, `useLiveRunTracker`, `ArcMenu` 개선

## 확인 방법
- `npm run start` (Expo) 실행 후 여정 관련 라우트로 이동
- 검증: 리스트 페치, 디테일 렌더, 가이드/로딩 전환이 정상 동작하는지
- 점검: 라이브 러닝 트래커가 거리/페이스/시간을 안정적으로 갱신하는지, ArcMenu 액션이 정상 동작하는지

## 참고 사항
- 환경별 `utils/api/client.ts`의 `baseURL` 값 확인 필요
- `.env`는 커밋하지 않음, 권한은 `app.config.js` 및 네이티브 설정 확인

