### PR TITLE
feat(crew): modularize Crew screen, add detail screen, and reusable c…

### DIFF
--- a/Pages/CrewDetailScreen.tsx
+++ b/Pages/CrewDetailScreen.tsx
@@ -1,0 +1,523 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  StatusBar,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+} from "react-native";
+import {
+  getMyCrewDetail,
+  removeMember,
+  approveRequest,
+  rejectRequest,
+} from "../utils/api/crews";
+
+type Member = {
+  id: string;
+  nickname: string;
+  role: "ADMIN" | "MEMBER";
+  distance?: number;
+};
+type Applicant = { id: string; nickname: string; level?: string };
+
+export default function CrewDetailScreen() {
+  const [loading, setLoading] = useState(true);
+  const [role, setRole] = useState<"ADMIN" | "MEMBER">("MEMBER");
+  const [crewName, setCrewName] = useState("서울 러닝 크루");
+  const [crewInfo, setCrewInfo] = useState({
+    location: "활동 중",
+    members: "멤버 24명",
+    manager: "관리자",
+    totalDistance: "156km",
+    meetCount: "3회",
+    totalMembers: "2송",
+  });
+  const [members, setMembers] = useState<Member[]>([]);
+  const [pending, setPending] = useState<Applicant[]>([
+    { id: "1", nickname: "김러너", level: "함께 레이스 4'30\"" },
+    { id: "2", nickname: "박조거", level: "함께 레이스 5'00\"" },
+  ]);
+  const [selectedTab, setSelectedTab] = useState<"통계" | "멤버" | "설정">(
+    "통계"
+  );
+  const [mvpMember, setMvpMember] = useState({
+    name: "정진호",
+    distance: "28.5km",
+  });
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const detail = await getMyCrewDetail();
+      if (detail) {
+        setCrewName(detail.crew.name);
+        setRole(detail.role);
+        setMembers(detail.members as Member[]);
+        setPending(detail.pending as Applicant[]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const isAdmin = role === "ADMIN";
+
+  return (
+    <SafeAreaView style={s.container}>
+      <StatusBar barStyle="light-content" />
+
+      {/* 헤더 */}
+      <View style={s.blueHeader}>
+        <Text style={s.headerTime}>9:41</Text>
+        <View style={s.headerTop}>
+          <Text style={s.headerTitle}>크루</Text>
+          <TouchableOpacity style={s.searchIcon}>
+            <Text style={s.searchIconText}>🔍</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <ScrollView style={s.scrollView} showsVerticalScrollIndicator={false}>
+        {/* 크루 정보 카드 */}
+        <View style={s.crewInfoCard}>
+          <View style={s.crewHeader}>
+            <View style={s.crewAvatar} />
+            <View style={s.crewHeaderText}>
+              <Text style={s.crewName}>{crewName}</Text>
+              <Text style={s.crewSubInfo}>
+                {crewInfo.location} • {crewInfo.members} • {crewInfo.manager}
+              </Text>
+            </View>
+          </View>
+
+          <View style={s.statsRow}>
+            <View style={s.statItem}>
+              <Text style={s.statValue}>{crewInfo.totalDistance}</Text>
+              <Text style={s.statLabel}>이번 달</Text>
+            </View>
+            <View style={s.statItem}>
+              <Text style={s.statValue}>{crewInfo.meetCount}</Text>
+              <Text style={s.statLabel}>내 손위</Text>
+            </View>
+            <View style={s.statItem}>
+              <Text style={s.statValue}>{crewInfo.totalMembers}</Text>
+              <Text style={s.statLabel}>대열 순위</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* 가입 신청 (관리자만) */}
+        {isAdmin && pending.length > 0 && (
+          <View style={s.applicationCard}>
+            <Text style={s.applicationTitle}>가입 신청</Text>
+            {pending.map((a) => (
+              <View key={a.id} style={s.applicationRow}>
+                <View style={s.applicantInfo}>
+                  <View style={s.applicantAvatar} />
+                  <View>
+                    <Text style={s.applicantName}>{a.nickname}</Text>
+                    <Text style={s.applicantLevel}>{a.level}</Text>
+                  </View>
+                </View>
+                <View style={s.applicationBtns}>
+                  <TouchableOpacity
+                    style={[s.applicationBtn, s.approveBtn]}
+                    onPress={async () => {
+                      await approveRequest(a.id);
+                      await refresh();
+                    }}
+                  >
+                    <Text style={s.approveBtnText}>승인</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[s.applicationBtn, s.rejectBtn]}
+                    onPress={async () => {
+                      await rejectRequest(a.id);
+                      await refresh();
+                    }}
+                  >
+                    <Text style={s.rejectBtnText}>거부</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* 탭 메뉴 */}
+        <View style={s.tabContainer}>
+          <TouchableOpacity
+            style={[s.tab, selectedTab === "통계" && s.activeTab]}
+            onPress={() => setSelectedTab("통계")}
+          >
+            <Text
+              style={[s.tabText, selectedTab === "통계" && s.activeTabText]}
+            >
+              통계
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[s.tab, selectedTab === "멤버" && s.activeTab]}
+            onPress={() => setSelectedTab("멤버")}
+          >
+            <Text
+              style={[s.tabText, selectedTab === "멤버" && s.activeTabText]}
+            >
+              멤버
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[s.tab, selectedTab === "설정" && s.activeTab]}
+            onPress={() => setSelectedTab("설정")}
+          >
+            <Text
+              style={[s.tabText, selectedTab === "설정" && s.activeTabText]}
+            >
+              설정
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* 통계 탭 내용 */}
+        {selectedTab === "통계" && (
+          <>
+            {/* 크루 통계 */}
+            <View style={s.statsSection}>
+              <View style={s.statsSectionHeader}>
+                <Text style={s.statsSectionTitle}>크루 통계</Text>
+                <View style={s.filterButtons}>
+                  <TouchableOpacity style={s.filterBtn}>
+                    <Text style={s.filterBtnText}>주간</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity style={s.filterBtnInactive}>
+                    <Text style={s.filterBtnInactiveText}>월간</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+
+              <View style={s.statsCards}>
+                <View style={s.statsCard}>
+                  <Text style={s.statsCardValue}>486km</Text>
+                  <Text style={s.statsCardLabel}>총 누적 거리</Text>
+                </View>
+                <View style={s.statsCard}>
+                  <Text style={s.statsCardValue}>18회</Text>
+                  <Text style={s.statsCardLabel}>그룹 러닝</Text>
+                </View>
+              </View>
+            </View>
+
+            {/* MVP 섹션 */}
+            <View style={s.mvpSection}>
+              <View style={s.mvpHeader}>
+                <Text style={s.mvpTitle}>🏆 이번 주 MVP</Text>
+                <Text style={s.mvpDate}>3월 18일 - 3월 24일</Text>
+              </View>
+              <View style={s.mvpCard}>
+                <View style={s.mvpAvatar} />
+                <View style={s.mvpInfo}>
+                  <Text style={s.mvpName}>{mvpMember.name}</Text>
+                  <Text style={s.mvpDistance}>
+                    주간 거리: {mvpMember.distance}
+                  </Text>
+                </View>
+                <View style={s.mvpBadge}>
+                  <Text style={s.mvpBadgeText}>MVP</Text>
+                </View>
+              </View>
+            </View>
+          </>
+        )}
+
+        {/* 멤버 탭 내용 */}
+        {selectedTab === "멤버" && (
+          <View style={s.membersSection}>
+            <Text style={s.sectionTitle}>멤버 목록</Text>
+            {members.map((m) => (
+              <View key={m.id} style={s.memberRow}>
+                <View style={s.memberInfo}>
+                  <View style={s.memberAvatar} />
+                  <Text style={s.memberName}>
+                    {m.nickname}
+                    {m.role === "ADMIN" ? " (관리자)" : ""}
+                  </Text>
+                </View>
+                {isAdmin && m.role !== "ADMIN" && (
+                  <TouchableOpacity
+                    style={s.kickBtn}
+                    onPress={() => {
+                      Alert.alert("확인", `${m.nickname} 님을 내보낼까요?`, [
+                        { text: "취소", style: "cancel" },
+                        {
+                          text: "내보내기",
+                          style: "destructive",
+                          onPress: async () => {
+                            await removeMember(m.id);
+                            await refresh();
+                          },
+                        },
+                      ]);
+                    }}
+                  >
+                    <Text style={s.kickBtnText}>내보내기</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#F5F7FA" },
+  blueHeader: { backgroundColor: "#4A7FE8", paddingTop: 8 },
+  headerTime: {
+    color: "#fff",
+    fontSize: 14,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  headerTop: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  headerTitle: { fontSize: 20, fontWeight: "700", color: "#fff" },
+  searchIcon: { padding: 4 },
+  searchIconText: { fontSize: 22 },
+  scrollView: { flex: 1 },
+
+  // 크루 정보 카드
+  crewInfoCard: {
+    backgroundColor: "#5B8FEE",
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 16,
+    padding: 20,
+  },
+  crewHeader: { flexDirection: "row", marginBottom: 20 },
+  crewAvatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: "#FFB4B4",
+    marginRight: 12,
+  },
+  crewHeaderText: { flex: 1, justifyContent: "center" },
+  crewName: { fontSize: 18, fontWeight: "700", color: "#fff", marginBottom: 4 },
+  crewSubInfo: { fontSize: 13, color: "rgba(255,255,255,0.8)" },
+  statsRow: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+  },
+  statItem: { alignItems: "center" },
+  statValue: {
+    fontSize: 20,
+    fontWeight: "800",
+    color: "#fff",
+    marginBottom: 4,
+  },
+  statLabel: { fontSize: 12, color: "rgba(255,255,255,0.8)" },
+
+  // 가입 신청
+  applicationCard: {
+    backgroundColor: "#FFF8E1",
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 12,
+    padding: 16,
+  },
+  applicationTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#000",
+    marginBottom: 12,
+  },
+  applicationRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  applicantInfo: { flexDirection: "row", alignItems: "center", flex: 1 },
+  applicantAvatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#FFB4B4",
+    marginRight: 12,
+  },
+  applicantName: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#000",
+    marginBottom: 2,
+  },
+  applicantLevel: { fontSize: 12, color: "#666" },
+  applicationBtns: { flexDirection: "row", gap: 8 },
+  applicationBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+  },
+  approveBtn: { backgroundColor: "#00C896" },
+  rejectBtn: { backgroundColor: "#FF6B6B" },
+  approveBtnText: { color: "#fff", fontSize: 13, fontWeight: "700" },
+  rejectBtnText: { color: "#fff", fontSize: 13, fontWeight: "700" },
+
+  // 탭
+  tabContainer: {
+    flexDirection: "row",
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E7EB",
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  activeTab: {
+    borderBottomWidth: 2,
+    borderBottomColor: "#4A7FE8",
+  },
+  tabText: { fontSize: 15, color: "#9CA3AF", fontWeight: "600" },
+  activeTabText: { color: "#4A7FE8", fontWeight: "700" },
+
+  // 통계 섹션
+  statsSection: {
+    backgroundColor: "#fff",
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 12,
+    padding: 16,
+  },
+  statsSectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  statsSectionTitle: { fontSize: 16, fontWeight: "700", color: "#000" },
+  filterButtons: { flexDirection: "row", gap: 8 },
+  filterBtn: {
+    backgroundColor: "#4A7FE8",
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+  },
+  filterBtnText: { color: "#fff", fontSize: 12, fontWeight: "600" },
+  filterBtnInactive: {
+    backgroundColor: "#F3F4F6",
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+  },
+  filterBtnInactiveText: { color: "#6B7280", fontSize: 12, fontWeight: "600" },
+  statsCards: { flexDirection: "row", gap: 12 },
+  statsCard: {
+    flex: 1,
+    backgroundColor: "#F9FAFB",
+    padding: 20,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  statsCardValue: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: "#4A7FE8",
+    marginBottom: 4,
+  },
+  statsCardLabel: { fontSize: 12, color: "#6B7280" },
+
+  // MVP 섹션
+  mvpSection: {
+    backgroundColor: "#3A3A3A",
+    marginHorizontal: 16,
+    marginTop: 16,
+    marginBottom: 16,
+    borderRadius: 12,
+    padding: 16,
+  },
+  mvpHeader: { marginBottom: 16 },
+  mvpTitle: { fontSize: 16, fontWeight: "700", color: "#fff", marginBottom: 4 },
+  mvpDate: { fontSize: 12, color: "#9CA3AF" },
+  mvpCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#4A4A4A",
+    padding: 12,
+    borderRadius: 12,
+  },
+  mvpAvatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: "#FFB4B4",
+    marginRight: 12,
+  },
+  mvpInfo: { flex: 1 },
+  mvpName: { fontSize: 16, fontWeight: "700", color: "#fff", marginBottom: 4 },
+  mvpDistance: { fontSize: 13, color: "#9CA3AF" },
+  mvpBadge: {
+    backgroundColor: "#6B7280",
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+  },
+  mvpBadgeText: { color: "#fff", fontSize: 12, fontWeight: "700" },
+
+  // 멤버 섹션
+  membersSection: {
+    backgroundColor: "#fff",
+    marginHorizontal: 16,
+    marginTop: 16,
+    marginBottom: 16,
+    borderRadius: 12,
+    padding: 16,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#000",
+    marginBottom: 12,
+  },
+  memberRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#F3F4F6",
+  },
+  memberInfo: { flexDirection: "row", alignItems: "center" },
+  memberAvatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#E5E7EB",
+    marginRight: 12,
+  },
+  memberName: { fontSize: 15, color: "#111827", fontWeight: "500" },
+  kickBtn: {
+    backgroundColor: "#F3F4F6",
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+  },
+  kickBtnText: { color: "#111827", fontSize: 13, fontWeight: "600" },
+});

--- a/Pages/CrewScreen.tsx
+++ b/Pages/CrewScreen.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import { View, Text, StyleSheet, SafeAreaView, StatusBar, ScrollView, TouchableOpacity } from "react-native";
+import TopCrewItem from "../components/Crew/TopCrewItem";
+import CrewCard from "../components/Crew/CrewCard";
+import SearchBar from "../components/Crew/SearchBar";
+import MyCrewCard from "../components/Crew/MyCrewCard";
+import { useCrewData } from "../hooks/useCrewData";
+import { useNavigation } from "@react-navigation/native";
+import CreateCrewSheet from "../components/Crew/CreateCrewSheet";
+import CrewPreviewSheet from "../components/Crew/CrewPreviewSheet";
+
+export default function CrewScreen() {
+  const [search, setSearch] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [selected, setSelected] = useState<{ id?: string; name: string; description?: string; progress?: string } | null>(null);
+  const { topCrews, crews, myCrew, createMyCrew, joinExistingCrew } = useCrewData(search);
+  // 탭 내비게이터 사용: 개별 화면에서 하단 바를 렌더하지 않음
+  const navigation = useNavigation<any>();
+
+  return (
+    <SafeAreaView style={s.container}>
+      <StatusBar barStyle="light-content" />
+
+      {/* 헤더 */}
+      <View style={s.header}>
+        <Text style={s.headerTime}>9:41</Text>
+      </View>
+
+      <ScrollView style={{ flex: 1 }} showsVerticalScrollIndicator={false}>
+        {/* 상단 랭킹 */}
+        <View style={s.topWrap}>
+          {topCrews.map((c, i) => (
+            <TopCrewItem
+              key={c.id}
+              rank={c.rank}
+              distance={c.distance}
+              highlight={i === 0}
+              onPress={() => {}}
+            />
+          ))}
+        </View>
+
+        {/* 목록 섹션 */}
+        <View style={s.content}>
+          <Text style={s.title}>크루 목록</Text>
+          <SearchBar value={search} onChangeText={setSearch} onSearch={() => {}} />
+
+          {/* 내 크루가 없으면 생성 유도 */}
+          {!myCrew && (
+            <View style={s.empty}>
+              <Text style={s.emptyIcon}>👥</Text>
+              <Text style={s.emptyText}>현재 크루가 없습니다</Text>
+              <TouchableOpacity style={s.createBtn} onPress={() => setCreateOpen(true)}>
+                <Text style={s.createBtnText}>크루 생성</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* 내 크루 고정 노출 (1번 위치) */}
+          {myCrew && (
+            <MyCrewCard
+              name={myCrew.name}
+              description={myCrew.description}
+              progress={myCrew.progress}
+              onPress={() => navigation.navigate("CrewDetail")}
+            />
+          )}
+
+          {/* 목록 */}
+          {crews.map((c) => (
+            <CrewCard
+              key={c.id}
+              name={c.name}
+              description={c.description}
+              progress={c.progress}
+              onPress={() => {
+                if (!myCrew) {
+                  setSelected({ id: c.id, name: c.name, description: c.description, progress: c.progress });
+                  setPreviewOpen(true);
+                }
+              }}
+            />
+          ))}
+        </View>
+      </ScrollView>
+
+      {/* 탭 내비게이터 사용으로 하단 바는 전역에서 렌더링됨 */}
+
+      {/* 크루 생성 바텀 시트 */}
+      <CreateCrewSheet
+        visible={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSubmit={async (name, description) => {
+          await createMyCrew(name, description);
+        }}
+      />
+
+      {/* 크루 미리보기 (내 크루 없을 때 다른 크루 클릭 시) */}
+      <CrewPreviewSheet
+        visible={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        name={selected?.name || ""}
+        description={selected?.description}
+        progress={selected?.progress}
+        onJoin={selected ? async () => { await joinExistingCrew({ id: selected.id || "", name: selected.name, description: selected.description || "", progress: selected.progress || "0/0" }); setPreviewOpen(false);} : undefined}
+      />
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+  header: { backgroundColor: "#4A90E2", padding: 16, paddingTop: 8 },
+  headerTime: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  topWrap: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    backgroundColor: "#4A90E2",
+    paddingVertical: 24,
+    paddingHorizontal: 16,
+  },
+  content: {
+    flex: 1,
+    backgroundColor: "#fff",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    marginTop: -20,
+    paddingTop: 24,
+    paddingHorizontal: 16,
+  },
+  title: { fontSize: 20, fontWeight: "700", marginBottom: 16, color: "#000" },
+  empty: { alignItems: "center", paddingVertical: 32, backgroundColor: "#FAFAFA", borderRadius: 12, marginBottom: 24 },
+  emptyIcon: { fontSize: 48, marginBottom: 12 },
+  emptyText: { fontSize: 14, color: "#999", marginBottom: 16 },
+  createBtn: { backgroundColor: "#000", paddingHorizontal: 24, paddingVertical: 10, borderRadius: 20 },
+  createBtnText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+});

--- a/components/Crew/CreateCrewSheet.tsx
+++ b/components/Crew/CreateCrewSheet.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { Modal, View, Text, StyleSheet, TextInput, TouchableOpacity } from "react-native";
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (name: string, description?: string) => Promise<void> | void;
+};
+
+export default function CreateCrewSheet({ visible, onClose, onSubmit }: Props) {
+  const [name, setName] = useState("");
+  const [desc, setDesc] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (!name.trim() || submitting) return;
+    try {
+      setSubmitting(true);
+      await onSubmit(name.trim(), desc.trim());
+      setName("");
+      setDesc("");
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={s.overlay}>
+        <View style={s.sheet}>
+          <View style={s.handle} />
+          <Text style={s.title}>크루 생성</Text>
+          <TextInput
+            style={s.input}
+            placeholder="크루 이름"
+            value={name}
+            onChangeText={setName}
+          />
+          <TextInput
+            style={[s.input, { height: 90 }]} 
+            placeholder="크루 소개 (선택)"
+            value={desc}
+            onChangeText={setDesc}
+            multiline
+          />
+          <View style={s.row}>
+            <TouchableOpacity style={[s.btn, s.cancel]} onPress={onClose} disabled={submitting}>
+              <Text style={s.cancelText}>취소</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[s.btn, s.primary, submitting && { opacity: 0.6 }]} onPress={submit}>
+              <Text style={s.primaryText}>{submitting ? "생성중…" : "생성"}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const s = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: "rgba(0,0,0,0.35)", justifyContent: "flex-end" },
+  sheet: {
+    backgroundColor: "#fff",
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 16,
+  },
+  handle: { alignSelf: "center", width: 44, height: 5, borderRadius: 999, backgroundColor: "#E5E7EB", marginBottom: 12 },
+  title: { fontSize: 18, fontWeight: "800", marginBottom: 12 },
+  input: {
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 12,
+  },
+  row: { flexDirection: "row", gap: 10 },
+  btn: { flex: 1, paddingVertical: 12, borderRadius: 10, alignItems: "center" },
+  cancel: { backgroundColor: "#F3F4F6" },
+  cancelText: { color: "#374151", fontWeight: "700" },
+  primary: { backgroundColor: "#111827" },
+  primaryText: { color: "#fff", fontWeight: "800" },
+});
+

--- a/components/Crew/CrewCard.tsx
+++ b/components/Crew/CrewCard.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageSourcePropType } from "react-native";
+
+type Props = {
+  name: string;
+  description: string;
+  progress: string;
+  image?: ImageSourcePropType;
+  onPress?: () => void;
+};
+
+export default function CrewCard({ name, description, progress, image, onPress }: Props) {
+  return (
+    <TouchableOpacity style={s.card} onPress={onPress} activeOpacity={0.8}>
+      <Image source={image || require("../../assets/people0.png")} style={s.img} />
+      <View style={s.info}>
+        <Text style={s.name}>{name}</Text>
+        <Text numberOfLines={1} style={s.desc}>{description}</Text>
+      </View>
+      <Text style={s.progress}>{progress}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const s = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#fff",
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  img: { width: 50, height: 50, borderRadius: 8 },
+  info: { flex: 1, marginLeft: 12 },
+  name: { fontSize: 16, fontWeight: "600", color: "#000", marginBottom: 4 },
+  desc: { fontSize: 13, color: "#666" },
+  progress: { fontSize: 14, color: "#999" },
+});
+

--- a/components/Crew/CrewPreviewSheet.tsx
+++ b/components/Crew/CrewPreviewSheet.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Modal, View, Text, StyleSheet, TouchableOpacity } from "react-native";
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  name: string;
+  description?: string;
+  progress?: string;
+  onJoin?: () => Promise<void> | void;
+};
+
+export default function CrewPreviewSheet({ visible, onClose, name, description, progress, onJoin }: Props) {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={s.overlay}>
+        <View style={s.sheet}>
+          <View style={s.handle} />
+          <Text style={s.title}>{name}</Text>
+          {!!description && <Text style={s.desc}>{description}</Text>}
+          {!!progress && <Text style={s.progress}>진행률 {progress}</Text>}
+          <View style={s.row}>
+            <TouchableOpacity style={[s.btn, s.cancel]} onPress={onClose}>
+              <Text style={s.cancelText}>닫기</Text>
+            </TouchableOpacity>
+            {onJoin && (
+              <TouchableOpacity style={[s.btn, s.primary]} onPress={onJoin}>
+                <Text style={s.primaryText}>참여하기</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const s = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: "rgba(0,0,0,0.35)", justifyContent: "flex-end" },
+  sheet: { backgroundColor: "#fff", borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 16 },
+  handle: { alignSelf: "center", width: 44, height: 5, borderRadius: 999, backgroundColor: "#E5E7EB", marginBottom: 12 },
+  title: { fontSize: 18, fontWeight: "800", marginBottom: 8 },
+  desc: { color: "#374151", marginBottom: 8 },
+  progress: { color: "#111827", fontWeight: "700", marginBottom: 12 },
+  row: { flexDirection: "row", gap: 10 },
+  btn: { flex: 1, paddingVertical: 12, borderRadius: 10, alignItems: "center" },
+  cancel: { backgroundColor: "#F3F4F6" },
+  cancelText: { color: "#374151", fontWeight: "700" },
+  primary: { backgroundColor: "#111827" },
+  primaryText: { color: "#fff", fontWeight: "800" },
+});
+

--- a/components/Crew/MyCrewCard.tsx
+++ b/components/Crew/MyCrewCard.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+
+type Props = {
+  name: string;
+  description?: string;
+  progress?: string;
+  onPress?: () => void;
+};
+
+export default function MyCrewCard({ name, description, progress, onPress }: Props) {
+  return (
+    <TouchableOpacity style={s.card} onPress={onPress} activeOpacity={0.85}>
+      <View style={s.badge}><Text style={s.badgeText}>내 크루</Text></View>
+      <Text style={s.name}>{name}</Text>
+      {!!description && <Text style={s.desc} numberOfLines={2}>{description}</Text>}
+      {!!progress && <Text style={s.progress}>{progress}</Text>}
+    </TouchableOpacity>
+  );
+}
+
+const s = StyleSheet.create({
+  card: {
+    backgroundColor: "#E8F2FF",
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "#D0E4FF",
+  },
+  badge: {
+    alignSelf: "flex-start",
+    backgroundColor: "#2B6CB0",
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    marginBottom: 8,
+  },
+  badgeText: { color: "#fff", fontSize: 12, fontWeight: "700" },
+  name: { fontSize: 18, fontWeight: "800", color: "#1A365D", marginBottom: 4 },
+  desc: { color: "#2A4365", marginBottom: 8 },
+  progress: { color: "#1A365D", fontWeight: "600" },
+});
+

--- a/components/Crew/SearchBar.tsx
+++ b/components/Crew/SearchBar.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { View, TextInput, StyleSheet, TouchableOpacity, Text } from "react-native";
+
+type Props = {
+  value: string;
+  onChangeText: (t: string) => void;
+  onSearch?: () => void;
+};
+
+export default function SearchBar({ value, onChangeText, onSearch }: Props) {
+  return (
+    <View style={s.container}>
+      <TextInput
+        style={s.input}
+        placeholder="크루를 검색해 보세요"
+        placeholderTextColor="#999"
+        value={value}
+        onChangeText={onChangeText}
+        returnKeyType="search"
+        onSubmitEditing={onSearch}
+      />
+      <TouchableOpacity onPress={onSearch} style={s.btn}>
+        <Text style={s.icon}>🔍</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#F5F5F5",
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    marginBottom: 20,
+  },
+  input: { flex: 1, paddingVertical: 14, fontSize: 15, color: "#000" },
+  btn: { padding: 4 },
+  icon: { fontSize: 20 },
+});
+

--- a/components/Crew/TopCrewItem.tsx
+++ b/components/Crew/TopCrewItem.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { View, Text, Image, StyleSheet, TouchableOpacity, ImageSourcePropType } from "react-native";
+
+type Props = {
+  rank: string;
+  distance: string;
+  image?: ImageSourcePropType;
+  highlight?: boolean; // 1등 강조
+  onPress?: () => void;
+};
+
+export default function TopCrewItem({ rank, distance, image, highlight, onPress }: Props) {
+  return (
+    <TouchableOpacity style={s.wrap} onPress={onPress} activeOpacity={0.8}>
+      <View style={[s.imgWrap, highlight && s.highlight]}>
+        <Image source={image || require("../../assets/people0.png")} style={s.img} />
+      </View>
+      <Text style={s.rank}>{rank}</Text>
+      <Text style={s.distance}>{distance}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: { alignItems: "center" },
+  imgWrap: {
+    width: 70,
+    height: 70,
+    borderRadius: 35,
+    backgroundColor: "#fff",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  highlight: { width: 80, height: 80, borderRadius: 40, borderWidth: 3, borderColor: "#FFD700" },
+  img: { width: 60, height: 60, borderRadius: 30 },
+  rank: { color: "#fff", fontSize: 12, fontWeight: "600", marginBottom: 4 },
+  distance: { color: "#fff", fontSize: 11 },
+});
+

--- a/hooks/useCrewData.ts
+++ b/hooks/useCrewData.ts
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import type { TopCrewItemData } from "../types/Crew";
+import type { Crew } from "../utils/api/crews";
+import { getMyCrew, listCrews, createCrew, joinCrew } from "../utils/api/crews";
+
+const RAW_TOP_CREWS: TopCrewItemData[] = [
+  { id: "2", rank: "1등 크루", name: "마리오 크루", distance: "1150km" },
+  { id: "1", rank: "2등 크루", name: "산책 크루", distance: "950km" },
+  { id: "3", rank: "3등 크루", name: "초록 크루", distance: "685km" },
+];
+
+export function useCrewData(searchText: string) {
+  const [myCrew, setMyCrew] = useState<Crew | null>(null);
+  const [crews, setCrews] = useState<Crew[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [m, list] = await Promise.all([
+        getMyCrew(),
+        listCrews(searchText),
+      ]);
+      setMyCrew(m);
+      // 내 크루가 목록에 있으면 중복 제거 후 최상단에 노출
+      const filtered = (list ?? []).filter((c) => !m || c.id !== m.id);
+      setCrews(filtered);
+    } catch (e: any) {
+      setError(e?.message || "크루 정보를 불러오지 못했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [searchText]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const topCrews = RAW_TOP_CREWS;
+
+  const finalList = useMemo(() => {
+    return myCrew ? [myCrew, ...crews] : crews;
+  }, [myCrew, crews]);
+
+  const ensureMyCrew = useCallback(async () => {
+    const created = await createCrew({ name: "내 크루", description: "함께 달려요" });
+    setMyCrew(created);
+  }, []);
+
+  const createMyCrew = useCallback(async (name: string, description?: string) => {
+    const created = await createCrew({ name, description });
+    setMyCrew(created);
+    // 목록에서 중복 제거
+    setCrews((prev) => prev.filter((c) => c.id !== created.id));
+    return created;
+  }, []);
+
+  const joinExistingCrew = useCallback(async (crew: Crew) => {
+    const joined = await joinCrew(crew);
+    setMyCrew(joined);
+    setCrews((prev) => prev.filter((c) => c.id !== joined.id));
+    return joined;
+  }, []);
+
+  return { topCrews, crews: finalList, myCrew, loading, error, refresh, ensureMyCrew, createMyCrew, joinExistingCrew };
+}

--- a/types/Crew.ts
+++ b/types/Crew.ts
@@ -1,0 +1,14 @@
+export interface CrewListItem {
+  id: string;
+  name: string;
+  description: string;
+  progress: string; // e.g., "1/50"
+}
+
+export interface TopCrewItemData {
+  id: string;
+  rank: string; // e.g., "1등 크루"
+  name: string;
+  distance: string; // e.g., "1150km"
+}
+


### PR DESCRIPTION
## Title : feat : crew

## description : 
크루 영역을 페이지 단위로 모듈화하고, 생성/미리보기 시트 및 상세(Admin/Member 분기) 플로우를 추가했습니다. 리스트에서는 내 크루를 항상 1번 위치(핀 고정) 로 노출합니다.

## Motivation :
- 내 크루 1번 고정으로 사용성이 높은 진입을 제공

- 크루 생성/미리보기를 Bottom Sheet에서 일관 처리

- 상세 화면에서 관리자(Admin)/일반(Member) 역할에 따라 UI·행동 분기

- nav PR의 중앙집중 탭 네비게이션 구조를 전제로 크루 플로우 정리

## ‼️ 주요 변경 (What Changed)

- 페이지 모듈화
>- CrewMain(크루 메인/리스트)



>- CrewDetail(크루 상세: 공통 레이아웃)

>- CrewDetailAdmin(관리자 패널: 가입 승인/거절, 멤버 내보내기)

>- CrewDetailMember(일반 멤버 뷰)

- 시트 구성

>- CrewCreateSheet(내 크루 없음 시 생성)

>- CrewPreviewSheet(타 크루 탭 시 미리보기)

- 정렬/고정 로직

>- 내 크루를 항상 인덱스 0에 고정(없으면 생성 시트 유도)

-라우팅/상태

>- 탭: tabs/crew → 메인 진입

>- 상세 진입 시 역할에 따라 Admin/Member 컴포넌트 분기

>- 전역 store(또는 query 캐시)에 myCrew, crewList, myRole 보관

- API 연동(프론트 기준 호출 지점 추가)

>- GET /v1/crews/me, GET /v1/crews, POST /v1/crews(생성)

>- GET /v1/crews/:id(상세), POST /v1/crews/:id/join(신청)

>- POST /v1/crews/:id/join/:reqId/approve|reject(관리자)

>- DELETE /v1/crews/:id/members/:userId(관리자: 내보내기)