### PR TITLE
feat : 엠블럼 축하 애니메이션 테스트 토글 추가

### DIFF
--- a/utils/featureFlags.ts
+++ b/utils/featureFlags.ts
@@ -1,0 +1,5 @@
+// Centralized feature flags for runtime toggles in development/testing
+// Toggle this to force the Emblem celebration animation at run completion
+// - true: Always show celebration after saving a run (for filming)
+// - false: Normal behavior (show only when emblem conditions are met)
+export const EMBLEM_CELEBRATION_TEST_MODE = true;


### PR DESCRIPTION
## 요약
- 러닝 종료 시 엠블럼 축하 애니메이션을 강제로 표시할 수 있는 테스트용 플래그 추가(영상 촬영 등 즉시 연출용).

## 변경 사항
- feat(running): `EMBLEM_CELEBRATION_TEST_MODE` 플래그 추가
  - 위치: `utils/featureFlags.ts`
  - 역할: 러닝 종료 후 저장 시, 조건 상관없이 축하 애니메이션을 강제로 표시할 수 있음.
  - 기본값: `false` (기존 동작 유지)

## 코드 경로
- 러닝 종료 시 처리: `src/features/running/screens/LiveRunningScreen.tsx`
  - 폰 모드/워치 모드 모두 완료 처리 시 플래그 적용
- 플래그 정의: `utils/featureFlags.ts`
- 크루 헤더 아이콘: `src/features/crew/screens/CrewScreen.tsx`

## 토글 방법
- 파일: `utils/featureFlags.ts`
- 설정:
  - 켜기(강제 표시): `export const EMBLEM_CELEBRATION_TEST_MODE = true;`
  - 끄기(원래 로직): `export const EMBLEM_CELEBRATION_TEST_MODE = false;`